### PR TITLE
chore(deps): update semantic-release to 19.0.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1100,18 +1100,54 @@
       }
     },
     "@semantic-release/commit-analyzer": {
-      "version": "8.0.1",
-      "resolved": "https://registry.npmjs.org/@semantic-release/commit-analyzer/-/commit-analyzer-8.0.1.tgz",
-      "integrity": "sha512-5bJma/oB7B4MtwUkZC2Bf7O1MHfi4gWe4mA+MIQ3lsEV0b422Bvl1z5HRpplDnMLHH3EXMoRdEng6Ds5wUqA3A==",
+      "version": "9.0.2",
+      "resolved": "https://registry.npmjs.org/@semantic-release/commit-analyzer/-/commit-analyzer-9.0.2.tgz",
+      "integrity": "sha512-E+dr6L+xIHZkX4zNMe6Rnwg4YQrWNXK+rNsvwOPpdFppvZO1olE2fIgWhv89TkQErygevbjsZFSIxp+u6w2e5g==",
       "dev": true,
       "requires": {
         "conventional-changelog-angular": "^5.0.0",
         "conventional-commits-filter": "^2.0.0",
-        "conventional-commits-parser": "^3.0.7",
+        "conventional-commits-parser": "^3.2.3",
         "debug": "^4.0.0",
-        "import-from": "^3.0.0",
+        "import-from": "^4.0.0",
         "lodash": "^4.17.4",
         "micromatch": "^4.0.2"
+      },
+      "dependencies": {
+        "conventional-commits-parser": {
+          "version": "3.2.4",
+          "resolved": "https://registry.npmjs.org/conventional-commits-parser/-/conventional-commits-parser-3.2.4.tgz",
+          "integrity": "sha512-nK7sAtfi+QXbxHCYfhpZsfRtaitZLIA6889kFIouLvz6repszQDgxBu7wf2WbU+Dco7sAnNCJYERCwt54WPC2Q==",
+          "dev": true,
+          "requires": {
+            "JSONStream": "^1.0.4",
+            "is-text-path": "^1.0.1",
+            "lodash": "^4.17.15",
+            "meow": "^8.0.0",
+            "split2": "^3.0.0",
+            "through2": "^4.0.0"
+          }
+        },
+        "readable-stream": {
+          "version": "3.6.0",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
+          "integrity": "sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==",
+          "dev": true,
+          "requires": {
+            "inherits": "^2.0.3",
+            "string_decoder": "^1.1.1",
+            "util-deprecate": "^1.0.1"
+          }
+        },
+        "split2": {
+          "version": "3.2.2",
+          "resolved": "https://registry.npmjs.org/split2/-/split2-3.2.2.tgz",
+          "integrity": "sha512-9NThjpgZnifTkJpzTZ7Eue85S49QwpNhZTq6GRJwObb6jnLFNGB7Qm73V5HewTROPyxD0C29xqmaI68bQtV+hg==",
+          "dev": true,
+          "requires": {
+            "readable-stream": "^3.0.0"
+          }
+        }
       }
     },
     "@semantic-release/error": {
@@ -1137,9 +1173,9 @@
       }
     },
     "@semantic-release/github": {
-      "version": "7.2.3",
-      "resolved": "https://registry.npmjs.org/@semantic-release/github/-/github-7.2.3.tgz",
-      "integrity": "sha512-lWjIVDLal+EQBzy697ayUNN8MoBpp+jYIyW2luOdqn5XBH4d9bQGfTnjuLyzARZBHejqh932HVjiH/j4+R7VHw==",
+      "version": "8.0.4",
+      "resolved": "https://registry.npmjs.org/@semantic-release/github/-/github-8.0.4.tgz",
+      "integrity": "sha512-But4e8oqqP3anZI5tjzZssZc2J6eoUdeeE0s7LVKKwyiAXJiQDWNNvtPOpgG2DsIz4+Exuse7cEQgjGMxwtLmg==",
       "dev": true,
       "requires": {
         "@octokit/rest": "^18.0.0",
@@ -1150,11 +1186,11 @@
         "dir-glob": "^3.0.0",
         "fs-extra": "^10.0.0",
         "globby": "^11.0.0",
-        "http-proxy-agent": "^4.0.0",
+        "http-proxy-agent": "^5.0.0",
         "https-proxy-agent": "^5.0.0",
         "issue-parser": "^6.0.0",
         "lodash": "^4.17.4",
-        "mime": "^2.4.3",
+        "mime": "^3.0.0",
         "p-filter": "^2.0.0",
         "p-retry": "^4.0.0",
         "url-join": "^4.0.0"
@@ -1174,19 +1210,19 @@
       }
     },
     "@semantic-release/npm": {
-      "version": "7.1.3",
-      "resolved": "https://registry.npmjs.org/@semantic-release/npm/-/npm-7.1.3.tgz",
-      "integrity": "sha512-x52kQ/jR09WjuWdaTEHgQCvZYMOTx68WnS+TZ4fya5ZAJw4oRtJETtrvUw10FdfM28d/keInQdc66R1Gw5+OEQ==",
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/@semantic-release/npm/-/npm-9.0.1.tgz",
+      "integrity": "sha512-I5nVZklxBzfMFwemhRNbSrkiN/dsH3c7K9+KSk6jUnq0rdLFUuJt7EBsysq4Ir3moajQgFkfEryEHPqiKJj20g==",
       "dev": true,
       "requires": {
-        "@semantic-release/error": "^2.2.0",
+        "@semantic-release/error": "^3.0.0",
         "aggregate-error": "^3.0.0",
         "execa": "^5.0.0",
         "fs-extra": "^10.0.0",
         "lodash": "^4.17.15",
         "nerf-dart": "^1.0.0",
         "normalize-url": "^6.0.0",
-        "npm": "^7.0.0",
+        "npm": "^8.3.0",
         "rc": "^1.2.8",
         "read-pkg": "^5.0.0",
         "registry-auth-token": "^4.0.0",
@@ -1194,6 +1230,12 @@
         "tempy": "^1.0.0"
       },
       "dependencies": {
+        "@semantic-release/error": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/@semantic-release/error/-/error-3.0.0.tgz",
+          "integrity": "sha512-5hiM4Un+tpl4cKw3lV4UgzJj+SmfNIDCLLw0TepzQxz9ZGV5ixnqkzIVF+3tp0ZHgcMKE+VNGHJjEeyFG2dcSw==",
+          "dev": true
+        },
         "execa": {
           "version": "5.1.1",
           "resolved": "https://registry.npmjs.org/execa/-/execa-5.1.1.tgz",
@@ -1237,28 +1279,62 @@
       }
     },
     "@semantic-release/release-notes-generator": {
-      "version": "9.0.3",
-      "resolved": "https://registry.npmjs.org/@semantic-release/release-notes-generator/-/release-notes-generator-9.0.3.tgz",
-      "integrity": "sha512-hMZyddr0u99OvM2SxVOIelHzly+PP3sYtJ8XOLHdMp8mrluN5/lpeTnIO27oeCYdupY/ndoGfvrqDjHqkSyhVg==",
+      "version": "10.0.3",
+      "resolved": "https://registry.npmjs.org/@semantic-release/release-notes-generator/-/release-notes-generator-10.0.3.tgz",
+      "integrity": "sha512-k4x4VhIKneOWoBGHkx0qZogNjCldLPRiAjnIpMnlUh6PtaWXp/T+C9U7/TaNDDtgDa5HMbHl4WlREdxHio6/3w==",
       "dev": true,
       "requires": {
         "conventional-changelog-angular": "^5.0.0",
-        "conventional-changelog-writer": "^4.0.0",
+        "conventional-changelog-writer": "^5.0.0",
         "conventional-commits-filter": "^2.0.0",
-        "conventional-commits-parser": "^3.0.0",
+        "conventional-commits-parser": "^3.2.3",
         "debug": "^4.0.0",
         "get-stream": "^6.0.0",
-        "import-from": "^3.0.0",
+        "import-from": "^4.0.0",
         "into-stream": "^6.0.0",
         "lodash": "^4.17.4",
         "read-pkg-up": "^7.0.0"
       },
       "dependencies": {
+        "conventional-commits-parser": {
+          "version": "3.2.4",
+          "resolved": "https://registry.npmjs.org/conventional-commits-parser/-/conventional-commits-parser-3.2.4.tgz",
+          "integrity": "sha512-nK7sAtfi+QXbxHCYfhpZsfRtaitZLIA6889kFIouLvz6repszQDgxBu7wf2WbU+Dco7sAnNCJYERCwt54WPC2Q==",
+          "dev": true,
+          "requires": {
+            "JSONStream": "^1.0.4",
+            "is-text-path": "^1.0.1",
+            "lodash": "^4.17.15",
+            "meow": "^8.0.0",
+            "split2": "^3.0.0",
+            "through2": "^4.0.0"
+          }
+        },
         "get-stream": {
           "version": "6.0.1",
           "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-6.0.1.tgz",
           "integrity": "sha512-ts6Wi+2j3jQjqi70w5AlN8DFnkSwC+MqmxEzdEALB2qXZYV3X/b1CTfgPLGJNMeAWxdPfU8FO1ms3NUfaHCPYg==",
           "dev": true
+        },
+        "readable-stream": {
+          "version": "3.6.0",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
+          "integrity": "sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==",
+          "dev": true,
+          "requires": {
+            "inherits": "^2.0.3",
+            "string_decoder": "^1.1.1",
+            "util-deprecate": "^1.0.1"
+          }
+        },
+        "split2": {
+          "version": "3.2.2",
+          "resolved": "https://registry.npmjs.org/split2/-/split2-3.2.2.tgz",
+          "integrity": "sha512-9NThjpgZnifTkJpzTZ7Eue85S49QwpNhZTq6GRJwObb6jnLFNGB7Qm73V5HewTROPyxD0C29xqmaI68bQtV+hg==",
+          "dev": true,
+          "requires": {
+            "readable-stream": "^3.0.0"
+          }
         }
       }
     },
@@ -1281,9 +1357,9 @@
       }
     },
     "@tootallnate/once": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/@tootallnate/once/-/once-1.1.2.tgz",
-      "integrity": "sha512-RbzJvlNzmRq5c3O09UipeuXno4tA1FE6ikOjxZK0tuxVv3412l64l5t1W5pj4+rJq9vpkm/kwiR07aZXnsKPxw==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@tootallnate/once/-/once-2.0.0.tgz",
+      "integrity": "sha512-XCuKFP5PS55gnMVu3dty8KPatLqUoy/ZYzDzAGCQ8JNFCkLXzmI7vNHCR+XpbZaMWQK/vQubr7PkYq8g470J/A==",
       "dev": true
     },
     "@types/babel__core": {
@@ -1653,18 +1729,18 @@
       "dev": true
     },
     "ansi-escapes": {
-      "version": "4.3.2",
-      "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-4.3.2.tgz",
-      "integrity": "sha512-gKXj5ALrKWQLsYG9jlTRmR/xKluxHV+Z9QEwNIgCfM1/uwPMCuzVVnh5mwTd+OuBZcwSIMbqssNWRm1lE51QaQ==",
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-5.0.0.tgz",
+      "integrity": "sha512-5GFMVX8HqE/TB+FuBJGuO5XG0WrsA6ptUqoODaT/n9mmUaZFkqnBueB4leqGBCmrUHnCnC4PCZTCd0E7QQ83bA==",
       "dev": true,
       "requires": {
-        "type-fest": "^0.21.3"
+        "type-fest": "^1.0.2"
       },
       "dependencies": {
         "type-fest": {
-          "version": "0.21.3",
-          "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.21.3.tgz",
-          "integrity": "sha512-t0rzBq87m3fVcduHDUFhKmyyX+9eo6WQjZvf51Ea/M0Q7+T374Jp1aUiyUl0GKxp8M/OETVHSDvmkyPgvX+X2w==",
+          "version": "1.4.0",
+          "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-1.4.0.tgz",
+          "integrity": "sha512-yGSza74xk0UG8k+pLh5oeoYirvIiWo5t0/o3zHHAO2tRDiZcxWP7fywNlXhqb6/r6sWvwi+RsyQMWhVLe4BVuA==",
           "dev": true
         }
       }
@@ -2303,15 +2379,14 @@
       }
     },
     "conventional-changelog-writer": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/conventional-changelog-writer/-/conventional-changelog-writer-4.1.0.tgz",
-      "integrity": "sha512-WwKcUp7WyXYGQmkLsX4QmU42AZ1lqlvRW9mqoyiQzdD+rJWbTepdWoKJuwXTS+yq79XKnQNa93/roViPQrAQgw==",
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/conventional-changelog-writer/-/conventional-changelog-writer-5.0.1.tgz",
+      "integrity": "sha512-5WsuKUfxW7suLblAbFnxAcrvf6r+0b7GvNaWUwUIk0bXMnENP/PEieGKVUQrjPqwPT4o3EPAASBXiY6iHooLOQ==",
       "dev": true,
       "requires": {
-        "compare-func": "^2.0.0",
         "conventional-commits-filter": "^2.0.7",
         "dateformat": "^3.0.0",
-        "handlebars": "^4.7.6",
+        "handlebars": "^4.7.7",
         "json-stringify-safe": "^5.0.1",
         "lodash": "^4.17.15",
         "meow": "^8.0.0",
@@ -3932,12 +4007,12 @@
       "dev": true
     },
     "http-proxy-agent": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-4.0.1.tgz",
-      "integrity": "sha512-k0zdNgqWTGA6aeIRVpvfVob4fL52dTfaehylg0Y4UvSySvOq/Y+BOyPrgpUrA7HylqvU8vIZGsRuXmspskV0Tg==",
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-5.0.0.tgz",
+      "integrity": "sha512-n2hY8YdoRE1i7r6M0w9DIw5GgZN0G25P8zLCRQ8rjXtTU3vsNFBI/vWK/UIeE6g5MUUz6avwAPXmL6Fy9D/90w==",
       "dev": true,
       "requires": {
-        "@tootallnate/once": "1",
+        "@tootallnate/once": "2",
         "agent-base": "6",
         "debug": "4"
       }
@@ -4069,13 +4144,10 @@
       }
     },
     "import-from": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/import-from/-/import-from-3.0.0.tgz",
-      "integrity": "sha512-CiuXOFFSzkU5x/CR0+z7T91Iht4CXgfCxVOFRhh2Zyhg5wOpWvvDLQUsWl+gcN+QscYBjez8hDCt85O7RLDttQ==",
-      "dev": true,
-      "requires": {
-        "resolve-from": "^5.0.0"
-      }
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/import-from/-/import-from-4.0.0.tgz",
+      "integrity": "sha512-P9J71vT5nLlDeV8FHs5nNxaLbrpfAV5cF5srvbZfpwpcJoM/xZR3hiv+q+SAnuSmuGbXMWud063iIMx/V/EWZQ==",
+      "dev": true
     },
     "import-local": {
       "version": "3.0.2",
@@ -5265,23 +5337,41 @@
       }
     },
     "marked": {
-      "version": "2.1.3",
-      "resolved": "https://registry.npmjs.org/marked/-/marked-2.1.3.tgz",
-      "integrity": "sha512-/Q+7MGzaETqifOMWYEA7HVMaZb4XbcRfaOzcSsHZEith83KGlvaSG33u0SKu89Mj5h+T8V2hM+8O45Qc5XTgwA==",
+      "version": "4.0.14",
+      "resolved": "https://registry.npmjs.org/marked/-/marked-4.0.14.tgz",
+      "integrity": "sha512-HL5sSPE/LP6U9qKgngIIPTthuxC0jrfxpYMZ3LdGDD3vTnLs59m2Z7r6+LNDR3ToqEQdkKd6YaaEfJhodJmijQ==",
       "dev": true
     },
     "marked-terminal": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/marked-terminal/-/marked-terminal-4.2.0.tgz",
-      "integrity": "sha512-DQfNRV9svZf0Dm9Cf5x5xaVJ1+XjxQW6XjFJ5HFkVyK52SDpj5PCBzS5X5r2w9nHr3mlB0T5201UMLue9fmhUw==",
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/marked-terminal/-/marked-terminal-5.1.1.tgz",
+      "integrity": "sha512-+cKTOx9P4l7HwINYhzbrBSyzgxO2HaHKGZGuB1orZsMIgXYaJyfidT81VXRdpelW/PcHEWxywscePVgI/oUF6g==",
       "dev": true,
       "requires": {
-        "ansi-escapes": "^4.3.1",
+        "ansi-escapes": "^5.0.0",
         "cardinal": "^2.1.1",
-        "chalk": "^4.1.0",
-        "cli-table3": "^0.6.0",
-        "node-emoji": "^1.10.0",
-        "supports-hyperlinks": "^2.1.0"
+        "chalk": "^5.0.0",
+        "cli-table3": "^0.6.1",
+        "node-emoji": "^1.11.0",
+        "supports-hyperlinks": "^2.2.0"
+      },
+      "dependencies": {
+        "chalk": {
+          "version": "5.0.1",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.0.1.tgz",
+          "integrity": "sha512-Fo07WOYGqMfCWHOzSXOt2CxDbC6skS/jO9ynEcmpANMoPrD+W1r1K6Vx7iNm+AQmETU1Xr2t+n8nzkV9t6xh3w==",
+          "dev": true
+        },
+        "supports-hyperlinks": {
+          "version": "2.2.0",
+          "resolved": "https://registry.npmjs.org/supports-hyperlinks/-/supports-hyperlinks-2.2.0.tgz",
+          "integrity": "sha512-6sXEzV5+I5j8Bmq9/vUphGRM/RJNT9SCURJLjwfOg51heRtguGWDzcaBlgAzKhQa0EVNpPEKzQuBwZ8S8WaCeQ==",
+          "dev": true,
+          "requires": {
+            "has-flag": "^4.0.0",
+            "supports-color": "^7.0.0"
+          }
+        }
       }
     },
     "meow": {
@@ -5326,9 +5416,9 @@
       }
     },
     "mime": {
-      "version": "2.6.0",
-      "resolved": "https://registry.npmjs.org/mime/-/mime-2.6.0.tgz",
-      "integrity": "sha512-USPkMeET31rOMiarsBNIHZKLGgvKc/LrjofAnBlOttf5ajRvqiRA8QsenbcooctK6d6Ts6aqZXBA+XbkKthiQg==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/mime/-/mime-3.0.0.tgz",
+      "integrity": "sha512-jSCU7/VB1loIWBZe14aEYHU/+1UMEHoaO7qxCOVJOw9GgH72VAWppxNcjU+x9a2k3GSIBXNKxXQFqRvvZ7vr3A==",
       "dev": true
     },
     "mime-db": {
@@ -5581,85 +5671,85 @@
       "dev": true
     },
     "npm": {
-      "version": "7.24.2",
-      "resolved": "https://registry.npmjs.org/npm/-/npm-7.24.2.tgz",
-      "integrity": "sha512-120p116CE8VMMZ+hk8IAb1inCPk4Dj3VZw29/n2g6UI77urJKVYb7FZUDW8hY+EBnfsjI/2yrobBgFyzo7YpVQ==",
+      "version": "8.7.0",
+      "resolved": "https://registry.npmjs.org/npm/-/npm-8.7.0.tgz",
+      "integrity": "sha512-fOSunmSa1K3dBv4YFoX54wew3PC6aYYDMGWBAonWRO4Yc7smYtk3nLrCda6+dtkTJwA8D4Tv/0wmnpYNgf5VFw==",
       "dev": true,
       "requires": {
         "@isaacs/string-locale-compare": "^1.1.0",
-        "@npmcli/arborist": "^2.9.0",
-        "@npmcli/ci-detect": "^1.2.0",
-        "@npmcli/config": "^2.3.0",
-        "@npmcli/map-workspaces": "^1.0.4",
-        "@npmcli/package-json": "^1.0.1",
-        "@npmcli/run-script": "^1.8.6",
+        "@npmcli/arborist": "^5.0.4",
+        "@npmcli/ci-detect": "^2.0.0",
+        "@npmcli/config": "^4.1.0",
+        "@npmcli/fs": "^2.1.0",
+        "@npmcli/map-workspaces": "^2.0.2",
+        "@npmcli/package-json": "^2.0.0",
+        "@npmcli/run-script": "^3.0.1",
         "abbrev": "~1.1.1",
-        "ansicolors": "~0.3.2",
-        "ansistyles": "~0.1.3",
         "archy": "~1.0.0",
-        "cacache": "^15.3.0",
+        "cacache": "^16.0.4",
         "chalk": "^4.1.2",
         "chownr": "^2.0.0",
-        "cli-columns": "^3.1.2",
-        "cli-table3": "^0.6.0",
-        "columnify": "~1.5.4",
+        "cli-columns": "^4.0.0",
+        "cli-table3": "^0.6.1",
+        "columnify": "^1.6.0",
         "fastest-levenshtein": "^1.0.12",
         "glob": "^7.2.0",
-        "graceful-fs": "^4.2.8",
-        "hosted-git-info": "^4.0.2",
-        "ini": "^2.0.0",
-        "init-package-json": "^2.0.5",
+        "graceful-fs": "^4.2.10",
+        "hosted-git-info": "^5.0.0",
+        "ini": "^3.0.0",
+        "init-package-json": "^3.0.2",
         "is-cidr": "^4.0.2",
         "json-parse-even-better-errors": "^2.3.1",
-        "libnpmaccess": "^4.0.2",
-        "libnpmdiff": "^2.0.4",
-        "libnpmexec": "^2.0.1",
-        "libnpmfund": "^1.1.0",
-        "libnpmhook": "^6.0.2",
-        "libnpmorg": "^2.0.2",
-        "libnpmpack": "^2.0.1",
-        "libnpmpublish": "^4.0.1",
-        "libnpmsearch": "^3.1.1",
-        "libnpmteam": "^2.0.3",
-        "libnpmversion": "^1.2.1",
-        "make-fetch-happen": "^9.1.0",
-        "minipass": "^3.1.3",
+        "libnpmaccess": "^6.0.2",
+        "libnpmdiff": "^4.0.2",
+        "libnpmexec": "^4.0.2",
+        "libnpmfund": "^3.0.1",
+        "libnpmhook": "^8.0.2",
+        "libnpmorg": "^4.0.2",
+        "libnpmpack": "^4.0.2",
+        "libnpmpublish": "^6.0.2",
+        "libnpmsearch": "^5.0.2",
+        "libnpmteam": "^4.0.2",
+        "libnpmversion": "^3.0.1",
+        "make-fetch-happen": "^10.1.2",
+        "minipass": "^3.1.6",
         "minipass-pipeline": "^1.2.4",
         "mkdirp": "^1.0.4",
         "mkdirp-infer-owner": "^2.0.0",
         "ms": "^2.1.2",
-        "node-gyp": "^7.1.2",
+        "node-gyp": "^9.0.0",
         "nopt": "^5.0.0",
-        "npm-audit-report": "^2.1.5",
-        "npm-install-checks": "^4.0.0",
-        "npm-package-arg": "^8.1.5",
-        "npm-pick-manifest": "^6.1.1",
-        "npm-profile": "^5.0.3",
-        "npm-registry-fetch": "^11.0.0",
+        "npm-audit-report": "^3.0.0",
+        "npm-install-checks": "^5.0.0",
+        "npm-package-arg": "^9.0.2",
+        "npm-pick-manifest": "^7.0.1",
+        "npm-profile": "^6.0.2",
+        "npm-registry-fetch": "^13.1.0",
         "npm-user-validate": "^1.0.1",
-        "npmlog": "^5.0.1",
+        "npmlog": "^6.0.1",
         "opener": "^1.5.2",
-        "pacote": "^11.3.5",
-        "parse-conflict-json": "^1.1.1",
+        "pacote": "^13.1.1",
+        "parse-conflict-json": "^2.0.2",
+        "proc-log": "^2.0.1",
         "qrcode-terminal": "^0.12.0",
         "read": "~1.0.7",
-        "read-package-json": "^4.1.1",
+        "read-package-json": "^5.0.0",
         "read-package-json-fast": "^2.0.3",
         "readdir-scoped-modules": "^1.1.0",
         "rimraf": "^3.0.2",
-        "semver": "^7.3.5",
-        "ssri": "^8.0.1",
+        "semver": "^7.3.6",
+        "ssri": "^9.0.0",
         "tar": "^6.1.11",
         "text-table": "~0.2.0",
         "tiny-relative-date": "^1.3.0",
-        "treeverse": "^1.0.4",
-        "validate-npm-package-name": "~3.0.0",
+        "treeverse": "^2.0.0",
+        "validate-npm-package-name": "^4.0.0",
         "which": "^2.0.2",
-        "write-file-atomic": "^3.0.3"
+        "write-file-atomic": "^4.0.1"
       },
       "dependencies": {
         "@gar/promisify": {
-          "version": "1.1.2",
+          "version": "1.1.3",
           "bundled": true,
           "dev": true
         },
@@ -5669,63 +5759,68 @@
           "dev": true
         },
         "@npmcli/arborist": {
-          "version": "2.9.0",
+          "version": "5.0.6",
           "bundled": true,
           "dev": true,
           "requires": {
-            "@isaacs/string-locale-compare": "^1.0.1",
+            "@isaacs/string-locale-compare": "^1.1.0",
             "@npmcli/installed-package-contents": "^1.0.7",
-            "@npmcli/map-workspaces": "^1.0.2",
-            "@npmcli/metavuln-calculator": "^1.1.0",
-            "@npmcli/move-file": "^1.1.0",
+            "@npmcli/map-workspaces": "^2.0.0",
+            "@npmcli/metavuln-calculator": "^3.0.1",
+            "@npmcli/move-file": "^2.0.0",
             "@npmcli/name-from-folder": "^1.0.1",
-            "@npmcli/node-gyp": "^1.0.1",
-            "@npmcli/package-json": "^1.0.1",
-            "@npmcli/run-script": "^1.8.2",
-            "bin-links": "^2.2.1",
-            "cacache": "^15.0.3",
+            "@npmcli/node-gyp": "^2.0.0",
+            "@npmcli/package-json": "^2.0.0",
+            "@npmcli/run-script": "^3.0.0",
+            "bin-links": "^3.0.0",
+            "cacache": "^16.0.0",
             "common-ancestor-path": "^1.0.1",
             "json-parse-even-better-errors": "^2.3.1",
             "json-stringify-nice": "^1.1.4",
             "mkdirp": "^1.0.4",
             "mkdirp-infer-owner": "^2.0.0",
-            "npm-install-checks": "^4.0.0",
-            "npm-package-arg": "^8.1.5",
-            "npm-pick-manifest": "^6.1.0",
-            "npm-registry-fetch": "^11.0.0",
-            "pacote": "^11.3.5",
-            "parse-conflict-json": "^1.1.1",
-            "proc-log": "^1.0.0",
+            "nopt": "^5.0.0",
+            "npm-install-checks": "^5.0.0",
+            "npm-package-arg": "^9.0.0",
+            "npm-pick-manifest": "^7.0.0",
+            "npm-registry-fetch": "^13.0.0",
+            "npmlog": "^6.0.1",
+            "pacote": "^13.0.5",
+            "parse-conflict-json": "^2.0.1",
+            "proc-log": "^2.0.0",
             "promise-all-reject-late": "^1.0.0",
             "promise-call-limit": "^1.0.1",
             "read-package-json-fast": "^2.0.2",
             "readdir-scoped-modules": "^1.1.0",
             "rimraf": "^3.0.2",
             "semver": "^7.3.5",
-            "ssri": "^8.0.1",
-            "treeverse": "^1.0.4",
+            "ssri": "^9.0.0",
+            "treeverse": "^2.0.0",
             "walk-up-path": "^1.0.0"
           }
         },
         "@npmcli/ci-detect": {
-          "version": "1.3.0",
+          "version": "2.0.0",
           "bundled": true,
           "dev": true
         },
         "@npmcli/config": {
-          "version": "2.3.0",
+          "version": "4.1.0",
           "bundled": true,
           "dev": true,
           "requires": {
-            "ini": "^2.0.0",
+            "@npmcli/map-workspaces": "^2.0.2",
+            "ini": "^3.0.0",
             "mkdirp-infer-owner": "^2.0.0",
             "nopt": "^5.0.0",
-            "semver": "^7.3.4",
+            "proc-log": "^2.0.0",
+            "read-package-json-fast": "^2.0.3",
+            "semver": "^7.3.5",
             "walk-up-path": "^1.0.0"
           }
         },
         "@npmcli/disparity-colors": {
-          "version": "1.0.1",
+          "version": "2.0.0",
           "bundled": true,
           "dev": true,
           "requires": {
@@ -5733,23 +5828,24 @@
           }
         },
         "@npmcli/fs": {
-          "version": "1.0.0",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "@gar/promisify": "^1.0.1",
-            "semver": "^7.3.5"
-          }
-        },
-        "@npmcli/git": {
           "version": "2.1.0",
           "bundled": true,
           "dev": true,
           "requires": {
-            "@npmcli/promise-spawn": "^1.3.2",
-            "lru-cache": "^6.0.0",
+            "@gar/promisify": "^1.1.3",
+            "semver": "^7.3.5"
+          }
+        },
+        "@npmcli/git": {
+          "version": "3.0.1",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "@npmcli/promise-spawn": "^3.0.0",
+            "lru-cache": "^7.4.4",
             "mkdirp": "^1.0.4",
-            "npm-pick-manifest": "^6.1.1",
+            "npm-pick-manifest": "^7.0.0",
+            "proc-log": "^2.0.0",
             "promise-inflight": "^1.0.1",
             "promise-retry": "^2.0.1",
             "semver": "^7.3.5",
@@ -5766,28 +5862,29 @@
           }
         },
         "@npmcli/map-workspaces": {
-          "version": "1.0.4",
+          "version": "2.0.2",
           "bundled": true,
           "dev": true,
           "requires": {
             "@npmcli/name-from-folder": "^1.0.1",
-            "glob": "^7.1.6",
-            "minimatch": "^3.0.4",
-            "read-package-json-fast": "^2.0.1"
+            "glob": "^7.2.0",
+            "minimatch": "^5.0.1",
+            "read-package-json-fast": "^2.0.3"
           }
         },
         "@npmcli/metavuln-calculator": {
-          "version": "1.1.1",
+          "version": "3.1.0",
           "bundled": true,
           "dev": true,
           "requires": {
-            "cacache": "^15.0.5",
-            "pacote": "^11.1.11",
-            "semver": "^7.3.2"
+            "cacache": "^16.0.0",
+            "json-parse-even-better-errors": "^2.3.1",
+            "pacote": "^13.0.3",
+            "semver": "^7.3.5"
           }
         },
         "@npmcli/move-file": {
-          "version": "1.1.2",
+          "version": "2.0.0",
           "bundled": true,
           "dev": true,
           "requires": {
@@ -5801,12 +5898,12 @@
           "dev": true
         },
         "@npmcli/node-gyp": {
-          "version": "1.0.2",
+          "version": "2.0.0",
           "bundled": true,
           "dev": true
         },
         "@npmcli/package-json": {
-          "version": "1.0.1",
+          "version": "2.0.0",
           "bundled": true,
           "dev": true,
           "requires": {
@@ -5814,7 +5911,7 @@
           }
         },
         "@npmcli/promise-spawn": {
-          "version": "1.3.2",
+          "version": "3.0.0",
           "bundled": true,
           "dev": true,
           "requires": {
@@ -5822,18 +5919,18 @@
           }
         },
         "@npmcli/run-script": {
-          "version": "1.8.6",
+          "version": "3.0.2",
           "bundled": true,
           "dev": true,
           "requires": {
-            "@npmcli/node-gyp": "^1.0.2",
-            "@npmcli/promise-spawn": "^1.3.2",
-            "node-gyp": "^7.1.0",
-            "read-package-json-fast": "^2.0.1"
+            "@npmcli/node-gyp": "^2.0.0",
+            "@npmcli/promise-spawn": "^3.0.0",
+            "node-gyp": "^9.0.0",
+            "read-package-json-fast": "^2.0.3"
           }
         },
         "@tootallnate/once": {
-          "version": "1.1.2",
+          "version": "2.0.0",
           "bundled": true,
           "dev": true
         },
@@ -5851,7 +5948,7 @@
           }
         },
         "agentkeepalive": {
-          "version": "4.1.4",
+          "version": "4.2.1",
           "bundled": true,
           "dev": true,
           "requires": {
@@ -5869,19 +5966,8 @@
             "indent-string": "^4.0.0"
           }
         },
-        "ajv": {
-          "version": "6.12.6",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "fast-deep-equal": "^3.1.1",
-            "fast-json-stable-stringify": "^2.0.0",
-            "json-schema-traverse": "^0.4.1",
-            "uri-js": "^4.2.2"
-          }
-        },
         "ansi-regex": {
-          "version": "2.1.1",
+          "version": "5.0.1",
           "bundled": true,
           "dev": true
         },
@@ -5892,16 +5978,6 @@
           "requires": {
             "color-convert": "^2.0.1"
           }
-        },
-        "ansicolors": {
-          "version": "0.3.2",
-          "bundled": true,
-          "dev": true
-        },
-        "ansistyles": {
-          "version": "0.1.3",
-          "bundled": true,
-          "dev": true
         },
         "aproba": {
           "version": "2.0.0",
@@ -5914,7 +5990,7 @@
           "dev": true
         },
         "are-we-there-yet": {
-          "version": "1.1.6",
+          "version": "3.0.0",
           "bundled": true,
           "dev": true,
           "requires": {
@@ -5927,58 +6003,22 @@
           "bundled": true,
           "dev": true
         },
-        "asn1": {
-          "version": "0.2.4",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "safer-buffer": "~2.1.0"
-          }
-        },
-        "assert-plus": {
-          "version": "1.0.0",
-          "bundled": true,
-          "dev": true
-        },
-        "asynckit": {
-          "version": "0.4.0",
-          "bundled": true,
-          "dev": true
-        },
-        "aws-sign2": {
-          "version": "0.7.0",
-          "bundled": true,
-          "dev": true
-        },
-        "aws4": {
-          "version": "1.11.0",
-          "bundled": true,
-          "dev": true
-        },
         "balanced-match": {
           "version": "1.0.2",
           "bundled": true,
           "dev": true
         },
-        "bcrypt-pbkdf": {
-          "version": "1.0.2",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "tweetnacl": "^0.14.3"
-          }
-        },
         "bin-links": {
-          "version": "2.2.1",
+          "version": "3.0.1",
           "bundled": true,
           "dev": true,
           "requires": {
-            "cmd-shim": "^4.0.1",
-            "mkdirp": "^1.0.3",
+            "cmd-shim": "^5.0.0",
+            "mkdirp-infer-owner": "^2.0.0",
             "npm-normalize-package-bin": "^1.0.0",
-            "read-cmd-shim": "^2.0.0",
+            "read-cmd-shim": "^3.0.0",
             "rimraf": "^3.0.0",
-            "write-file-atomic": "^3.0.3"
+            "write-file-atomic": "^4.0.0"
           }
         },
         "binary-extensions": {
@@ -5987,48 +6027,45 @@
           "dev": true
         },
         "brace-expansion": {
-          "version": "1.1.11",
+          "version": "2.0.1",
           "bundled": true,
           "dev": true,
           "requires": {
-            "balanced-match": "^1.0.0",
-            "concat-map": "0.0.1"
+            "balanced-match": "^1.0.0"
           }
         },
         "builtins": {
-          "version": "1.0.3",
-          "bundled": true,
-          "dev": true
-        },
-        "cacache": {
-          "version": "15.3.0",
+          "version": "5.0.0",
           "bundled": true,
           "dev": true,
           "requires": {
-            "@npmcli/fs": "^1.0.0",
-            "@npmcli/move-file": "^1.0.1",
+            "semver": "^7.0.0"
+          }
+        },
+        "cacache": {
+          "version": "16.0.4",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "@npmcli/fs": "^2.1.0",
+            "@npmcli/move-file": "^2.0.0",
             "chownr": "^2.0.0",
-            "fs-minipass": "^2.0.0",
-            "glob": "^7.1.4",
+            "fs-minipass": "^2.1.0",
+            "glob": "^7.2.0",
             "infer-owner": "^1.0.4",
-            "lru-cache": "^6.0.0",
-            "minipass": "^3.1.1",
+            "lru-cache": "^7.7.1",
+            "minipass": "^3.1.6",
             "minipass-collect": "^1.0.2",
             "minipass-flush": "^1.0.5",
-            "minipass-pipeline": "^1.2.2",
-            "mkdirp": "^1.0.3",
+            "minipass-pipeline": "^1.2.4",
+            "mkdirp": "^1.0.4",
             "p-map": "^4.0.0",
             "promise-inflight": "^1.0.1",
             "rimraf": "^3.0.2",
-            "ssri": "^8.0.1",
-            "tar": "^6.0.2",
+            "ssri": "^9.0.0",
+            "tar": "^6.1.11",
             "unique-filename": "^1.1.1"
           }
-        },
-        "caseless": {
-          "version": "0.12.0",
-          "bundled": true,
-          "dev": true
         },
         "chalk": {
           "version": "4.1.2",
@@ -6058,52 +6095,21 @@
           "dev": true
         },
         "cli-columns": {
-          "version": "3.1.2",
+          "version": "4.0.0",
           "bundled": true,
           "dev": true,
           "requires": {
-            "string-width": "^2.0.0",
-            "strip-ansi": "^3.0.1"
+            "string-width": "^4.2.3",
+            "strip-ansi": "^6.0.1"
           }
         },
         "cli-table3": {
-          "version": "0.6.0",
+          "version": "0.6.1",
           "bundled": true,
           "dev": true,
           "requires": {
-            "colors": "^1.1.2",
-            "object-assign": "^4.1.0",
+            "colors": "1.4.0",
             "string-width": "^4.2.0"
-          },
-          "dependencies": {
-            "ansi-regex": {
-              "version": "5.0.0",
-              "bundled": true,
-              "dev": true
-            },
-            "is-fullwidth-code-point": {
-              "version": "3.0.0",
-              "bundled": true,
-              "dev": true
-            },
-            "string-width": {
-              "version": "4.2.2",
-              "bundled": true,
-              "dev": true,
-              "requires": {
-                "emoji-regex": "^8.0.0",
-                "is-fullwidth-code-point": "^3.0.0",
-                "strip-ansi": "^6.0.0"
-              }
-            },
-            "strip-ansi": {
-              "version": "6.0.0",
-              "bundled": true,
-              "dev": true,
-              "requires": {
-                "ansi-regex": "^5.0.0"
-              }
-            }
           }
         },
         "clone": {
@@ -6112,17 +6118,12 @@
           "dev": true
         },
         "cmd-shim": {
-          "version": "4.1.0",
+          "version": "5.0.0",
           "bundled": true,
           "dev": true,
           "requires": {
             "mkdirp-infer-owner": "^2.0.0"
           }
-        },
-        "code-point-at": {
-          "version": "1.1.0",
-          "bundled": true,
-          "dev": true
         },
         "color-convert": {
           "version": "2.0.1",
@@ -6149,20 +6150,12 @@
           "optional": true
         },
         "columnify": {
-          "version": "1.5.4",
+          "version": "1.6.0",
           "bundled": true,
           "dev": true,
           "requires": {
-            "strip-ansi": "^3.0.0",
+            "strip-ansi": "^6.0.1",
             "wcwidth": "^1.0.0"
-          }
-        },
-        "combined-stream": {
-          "version": "1.0.8",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "delayed-stream": "~1.0.0"
           }
         },
         "common-ancestor-path": {
@@ -6180,21 +6173,8 @@
           "bundled": true,
           "dev": true
         },
-        "core-util-is": {
-          "version": "1.0.2",
-          "bundled": true,
-          "dev": true
-        },
-        "dashdash": {
-          "version": "1.14.1",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "assert-plus": "^1.0.0"
-          }
-        },
         "debug": {
-          "version": "4.3.2",
+          "version": "4.3.4",
           "bundled": true,
           "dev": true,
           "requires": {
@@ -6221,11 +6201,6 @@
             "clone": "^1.0.2"
           }
         },
-        "delayed-stream": {
-          "version": "1.0.0",
-          "bundled": true,
-          "dev": true
-        },
         "delegates": {
           "version": "1.0.0",
           "bundled": true,
@@ -6237,7 +6212,7 @@
           "dev": true
         },
         "dezalgo": {
-          "version": "1.0.3",
+          "version": "1.0.4",
           "bundled": true,
           "dev": true,
           "requires": {
@@ -6249,15 +6224,6 @@
           "version": "5.0.0",
           "bundled": true,
           "dev": true
-        },
-        "ecc-jsbn": {
-          "version": "0.1.2",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "jsbn": "~0.1.0",
-            "safer-buffer": "^2.1.0"
-          }
         },
         "emoji-regex": {
           "version": "8.0.0",
@@ -6283,33 +6249,8 @@
           "bundled": true,
           "dev": true
         },
-        "extend": {
-          "version": "3.0.2",
-          "bundled": true,
-          "dev": true
-        },
-        "extsprintf": {
-          "version": "1.3.0",
-          "bundled": true,
-          "dev": true
-        },
-        "fast-deep-equal": {
-          "version": "3.1.3",
-          "bundled": true,
-          "dev": true
-        },
-        "fast-json-stable-stringify": {
-          "version": "2.1.0",
-          "bundled": true,
-          "dev": true
-        },
         "fastest-levenshtein": {
           "version": "1.0.12",
-          "bundled": true,
-          "dev": true
-        },
-        "forever-agent": {
-          "version": "0.6.1",
           "bundled": true,
           "dev": true
         },
@@ -6332,27 +6273,18 @@
           "dev": true
         },
         "gauge": {
-          "version": "3.0.1",
+          "version": "4.0.4",
           "bundled": true,
           "dev": true,
           "requires": {
             "aproba": "^1.0.3 || ^2.0.0",
-            "color-support": "^1.1.2",
-            "console-control-strings": "^1.0.0",
+            "color-support": "^1.1.3",
+            "console-control-strings": "^1.1.0",
             "has-unicode": "^2.0.1",
-            "object-assign": "^4.1.1",
-            "signal-exit": "^3.0.0",
-            "string-width": "^1.0.1 || ^2.0.0",
-            "strip-ansi": "^3.0.1 || ^4.0.0",
-            "wide-align": "^1.1.2"
-          }
-        },
-        "getpass": {
-          "version": "0.1.7",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "assert-plus": "^1.0.0"
+            "signal-exit": "^3.0.7",
+            "string-width": "^4.2.3",
+            "strip-ansi": "^6.0.1",
+            "wide-align": "^1.1.5"
           }
         },
         "glob": {
@@ -6366,26 +6298,31 @@
             "minimatch": "^3.0.4",
             "once": "^1.3.0",
             "path-is-absolute": "^1.0.0"
+          },
+          "dependencies": {
+            "brace-expansion": {
+              "version": "1.1.11",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "balanced-match": "^1.0.0",
+                "concat-map": "0.0.1"
+              }
+            },
+            "minimatch": {
+              "version": "3.1.2",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "brace-expansion": "^1.1.7"
+              }
+            }
           }
         },
         "graceful-fs": {
-          "version": "4.2.8",
+          "version": "4.2.10",
           "bundled": true,
           "dev": true
-        },
-        "har-schema": {
-          "version": "2.0.0",
-          "bundled": true,
-          "dev": true
-        },
-        "har-validator": {
-          "version": "5.1.5",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "ajv": "^6.12.3",
-            "har-schema": "^2.0.0"
-          }
         },
         "has": {
           "version": "1.0.3",
@@ -6406,11 +6343,11 @@
           "dev": true
         },
         "hosted-git-info": {
-          "version": "4.0.2",
+          "version": "5.0.0",
           "bundled": true,
           "dev": true,
           "requires": {
-            "lru-cache": "^6.0.0"
+            "lru-cache": "^7.5.1"
           }
         },
         "http-cache-semantics": {
@@ -6419,23 +6356,13 @@
           "dev": true
         },
         "http-proxy-agent": {
-          "version": "4.0.1",
+          "version": "5.0.0",
           "bundled": true,
           "dev": true,
           "requires": {
-            "@tootallnate/once": "1",
+            "@tootallnate/once": "2",
             "agent-base": "6",
             "debug": "4"
-          }
-        },
-        "http-signature": {
-          "version": "1.2.0",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "assert-plus": "^1.0.0",
-            "jsprim": "^1.2.2",
-            "sshpk": "^1.7.0"
           }
         },
         "https-proxy-agent": {
@@ -6465,11 +6392,11 @@
           }
         },
         "ignore-walk": {
-          "version": "3.0.4",
+          "version": "5.0.1",
           "bundled": true,
           "dev": true,
           "requires": {
-            "minimatch": "^3.0.4"
+            "minimatch": "^5.0.1"
           }
         },
         "imurmurhash": {
@@ -6502,22 +6429,22 @@
           "dev": true
         },
         "ini": {
-          "version": "2.0.0",
+          "version": "3.0.0",
           "bundled": true,
           "dev": true
         },
         "init-package-json": {
-          "version": "2.0.5",
+          "version": "3.0.2",
           "bundled": true,
           "dev": true,
           "requires": {
-            "npm-package-arg": "^8.1.5",
+            "npm-package-arg": "^9.0.1",
             "promzard": "^0.3.0",
-            "read": "~1.0.1",
-            "read-package-json": "^4.1.1",
+            "read": "^1.0.7",
+            "read-package-json": "^5.0.0",
             "semver": "^7.3.5",
             "validate-npm-package-license": "^3.0.4",
-            "validate-npm-package-name": "^3.0.0"
+            "validate-npm-package-name": "^4.0.0"
           }
         },
         "ip": {
@@ -6539,7 +6466,7 @@
           }
         },
         "is-core-module": {
-          "version": "2.7.0",
+          "version": "2.8.1",
           "bundled": true,
           "dev": true,
           "requires": {
@@ -6547,7 +6474,7 @@
           }
         },
         "is-fullwidth-code-point": {
-          "version": "2.0.0",
+          "version": "3.0.0",
           "bundled": true,
           "dev": true
         },
@@ -6556,23 +6483,8 @@
           "bundled": true,
           "dev": true
         },
-        "is-typedarray": {
-          "version": "1.0.0",
-          "bundled": true,
-          "dev": true
-        },
         "isexe": {
           "version": "2.0.0",
-          "bundled": true,
-          "dev": true
-        },
-        "isstream": {
-          "version": "0.1.2",
-          "bundled": true,
-          "dev": true
-        },
-        "jsbn": {
-          "version": "0.1.1",
           "bundled": true,
           "dev": true
         },
@@ -6581,23 +6493,8 @@
           "bundled": true,
           "dev": true
         },
-        "json-schema": {
-          "version": "0.2.3",
-          "bundled": true,
-          "dev": true
-        },
-        "json-schema-traverse": {
-          "version": "0.4.1",
-          "bundled": true,
-          "dev": true
-        },
         "json-stringify-nice": {
           "version": "1.1.4",
-          "bundled": true,
-          "dev": true
-        },
-        "json-stringify-safe": {
-          "version": "5.0.1",
           "bundled": true,
           "dev": true
         },
@@ -6606,202 +6503,176 @@
           "bundled": true,
           "dev": true
         },
-        "jsprim": {
-          "version": "1.4.1",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "assert-plus": "1.0.0",
-            "extsprintf": "1.3.0",
-            "json-schema": "0.2.3",
-            "verror": "1.10.0"
-          }
-        },
         "just-diff": {
-          "version": "3.1.1",
+          "version": "5.0.1",
           "bundled": true,
           "dev": true
         },
         "just-diff-apply": {
-          "version": "3.0.0",
+          "version": "5.2.0",
           "bundled": true,
           "dev": true
         },
         "libnpmaccess": {
-          "version": "4.0.3",
+          "version": "6.0.3",
           "bundled": true,
           "dev": true,
           "requires": {
             "aproba": "^2.0.0",
             "minipass": "^3.1.1",
-            "npm-package-arg": "^8.1.2",
-            "npm-registry-fetch": "^11.0.0"
+            "npm-package-arg": "^9.0.1",
+            "npm-registry-fetch": "^13.0.0"
           }
         },
         "libnpmdiff": {
-          "version": "2.0.4",
+          "version": "4.0.3",
           "bundled": true,
           "dev": true,
           "requires": {
-            "@npmcli/disparity-colors": "^1.0.1",
+            "@npmcli/disparity-colors": "^2.0.0",
             "@npmcli/installed-package-contents": "^1.0.7",
             "binary-extensions": "^2.2.0",
             "diff": "^5.0.0",
-            "minimatch": "^3.0.4",
-            "npm-package-arg": "^8.1.4",
-            "pacote": "^11.3.4",
+            "minimatch": "^5.0.1",
+            "npm-package-arg": "^9.0.1",
+            "pacote": "^13.0.5",
             "tar": "^6.1.0"
           }
         },
         "libnpmexec": {
-          "version": "2.0.1",
+          "version": "4.0.3",
           "bundled": true,
           "dev": true,
           "requires": {
-            "@npmcli/arborist": "^2.3.0",
-            "@npmcli/ci-detect": "^1.3.0",
-            "@npmcli/run-script": "^1.8.4",
+            "@npmcli/arborist": "^5.0.0",
+            "@npmcli/ci-detect": "^2.0.0",
+            "@npmcli/run-script": "^3.0.0",
             "chalk": "^4.1.0",
             "mkdirp-infer-owner": "^2.0.0",
-            "npm-package-arg": "^8.1.2",
-            "pacote": "^11.3.1",
-            "proc-log": "^1.0.0",
+            "npm-package-arg": "^9.0.1",
+            "npmlog": "^6.0.1",
+            "pacote": "^13.0.5",
+            "proc-log": "^2.0.0",
             "read": "^1.0.7",
             "read-package-json-fast": "^2.0.2",
             "walk-up-path": "^1.0.0"
           }
         },
         "libnpmfund": {
-          "version": "1.1.0",
+          "version": "3.0.2",
           "bundled": true,
           "dev": true,
           "requires": {
-            "@npmcli/arborist": "^2.5.0"
+            "@npmcli/arborist": "^5.0.0"
           }
         },
         "libnpmhook": {
+          "version": "8.0.3",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "aproba": "^2.0.0",
+            "npm-registry-fetch": "^13.0.0"
+          }
+        },
+        "libnpmorg": {
+          "version": "4.0.3",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "aproba": "^2.0.0",
+            "npm-registry-fetch": "^13.0.0"
+          }
+        },
+        "libnpmpack": {
+          "version": "4.0.3",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "@npmcli/run-script": "^3.0.0",
+            "npm-package-arg": "^9.0.1",
+            "pacote": "^13.0.5"
+          }
+        },
+        "libnpmpublish": {
           "version": "6.0.3",
           "bundled": true,
           "dev": true,
           "requires": {
-            "aproba": "^2.0.0",
-            "npm-registry-fetch": "^11.0.0"
-          }
-        },
-        "libnpmorg": {
-          "version": "2.0.3",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "aproba": "^2.0.0",
-            "npm-registry-fetch": "^11.0.0"
-          }
-        },
-        "libnpmpack": {
-          "version": "2.0.1",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "@npmcli/run-script": "^1.8.3",
-            "npm-package-arg": "^8.1.0",
-            "pacote": "^11.2.6"
-          }
-        },
-        "libnpmpublish": {
-          "version": "4.0.2",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "normalize-package-data": "^3.0.2",
-            "npm-package-arg": "^8.1.2",
-            "npm-registry-fetch": "^11.0.0",
+            "normalize-package-data": "^4.0.0",
+            "npm-package-arg": "^9.0.1",
+            "npm-registry-fetch": "^13.0.0",
             "semver": "^7.1.3",
-            "ssri": "^8.0.1"
+            "ssri": "^9.0.0"
           }
         },
         "libnpmsearch": {
-          "version": "3.1.2",
+          "version": "5.0.3",
           "bundled": true,
           "dev": true,
           "requires": {
-            "npm-registry-fetch": "^11.0.0"
+            "npm-registry-fetch": "^13.0.0"
           }
         },
         "libnpmteam": {
-          "version": "2.0.4",
+          "version": "4.0.3",
           "bundled": true,
           "dev": true,
           "requires": {
             "aproba": "^2.0.0",
-            "npm-registry-fetch": "^11.0.0"
+            "npm-registry-fetch": "^13.0.0"
           }
         },
         "libnpmversion": {
-          "version": "1.2.1",
+          "version": "3.0.3",
           "bundled": true,
           "dev": true,
           "requires": {
-            "@npmcli/git": "^2.0.7",
-            "@npmcli/run-script": "^1.8.4",
+            "@npmcli/git": "^3.0.0",
+            "@npmcli/run-script": "^3.0.0",
             "json-parse-even-better-errors": "^2.3.1",
-            "semver": "^7.3.5",
-            "stringify-package": "^1.0.1"
+            "proc-log": "^2.0.0",
+            "semver": "^7.3.5"
           }
         },
         "lru-cache": {
-          "version": "6.0.0",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "yallist": "^4.0.0"
-          }
-        },
-        "make-fetch-happen": {
-          "version": "9.1.0",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "agentkeepalive": "^4.1.3",
-            "cacache": "^15.2.0",
-            "http-cache-semantics": "^4.1.0",
-            "http-proxy-agent": "^4.0.1",
-            "https-proxy-agent": "^5.0.0",
-            "is-lambda": "^1.0.1",
-            "lru-cache": "^6.0.0",
-            "minipass": "^3.1.3",
-            "minipass-collect": "^1.0.2",
-            "minipass-fetch": "^1.3.2",
-            "minipass-flush": "^1.0.5",
-            "minipass-pipeline": "^1.2.4",
-            "negotiator": "^0.6.2",
-            "promise-retry": "^2.0.1",
-            "socks-proxy-agent": "^6.0.0",
-            "ssri": "^8.0.0"
-          }
-        },
-        "mime-db": {
-          "version": "1.49.0",
+          "version": "7.7.3",
           "bundled": true,
           "dev": true
         },
-        "mime-types": {
-          "version": "2.1.32",
+        "make-fetch-happen": {
+          "version": "10.1.2",
           "bundled": true,
           "dev": true,
           "requires": {
-            "mime-db": "1.49.0"
+            "agentkeepalive": "^4.2.1",
+            "cacache": "^16.0.2",
+            "http-cache-semantics": "^4.1.0",
+            "http-proxy-agent": "^5.0.0",
+            "https-proxy-agent": "^5.0.0",
+            "is-lambda": "^1.0.1",
+            "lru-cache": "^7.7.1",
+            "minipass": "^3.1.6",
+            "minipass-collect": "^1.0.2",
+            "minipass-fetch": "^2.0.3",
+            "minipass-flush": "^1.0.5",
+            "minipass-pipeline": "^1.2.4",
+            "negotiator": "^0.6.3",
+            "promise-retry": "^2.0.1",
+            "socks-proxy-agent": "^6.1.1",
+            "ssri": "^9.0.0"
           }
         },
         "minimatch": {
-          "version": "3.0.4",
+          "version": "5.0.1",
           "bundled": true,
           "dev": true,
           "requires": {
-            "brace-expansion": "^1.1.7"
+            "brace-expansion": "^2.0.1"
           }
         },
         "minipass": {
-          "version": "3.1.5",
+          "version": "3.1.6",
           "bundled": true,
           "dev": true,
           "requires": {
@@ -6817,14 +6688,14 @@
           }
         },
         "minipass-fetch": {
-          "version": "1.4.1",
+          "version": "2.1.0",
           "bundled": true,
           "dev": true,
           "requires": {
-            "encoding": "^0.1.12",
-            "minipass": "^3.1.0",
+            "encoding": "^0.1.13",
+            "minipass": "^3.1.6",
             "minipass-sized": "^1.0.3",
-            "minizlib": "^2.0.0"
+            "minizlib": "^2.1.2"
           }
         },
         "minipass-flush": {
@@ -6895,76 +6766,25 @@
           "dev": true
         },
         "negotiator": {
-          "version": "0.6.2",
+          "version": "0.6.3",
           "bundled": true,
           "dev": true
         },
         "node-gyp": {
-          "version": "7.1.2",
+          "version": "9.0.0",
           "bundled": true,
           "dev": true,
           "requires": {
             "env-paths": "^2.2.0",
             "glob": "^7.1.4",
-            "graceful-fs": "^4.2.3",
+            "graceful-fs": "^4.2.6",
+            "make-fetch-happen": "^10.0.3",
             "nopt": "^5.0.0",
-            "npmlog": "^4.1.2",
-            "request": "^2.88.2",
+            "npmlog": "^6.0.0",
             "rimraf": "^3.0.2",
-            "semver": "^7.3.2",
-            "tar": "^6.0.2",
+            "semver": "^7.3.5",
+            "tar": "^6.1.2",
             "which": "^2.0.2"
-          },
-          "dependencies": {
-            "aproba": {
-              "version": "1.2.0",
-              "bundled": true,
-              "dev": true
-            },
-            "gauge": {
-              "version": "2.7.4",
-              "bundled": true,
-              "dev": true,
-              "requires": {
-                "aproba": "^1.0.3",
-                "console-control-strings": "^1.0.0",
-                "has-unicode": "^2.0.0",
-                "object-assign": "^4.1.0",
-                "signal-exit": "^3.0.0",
-                "string-width": "^1.0.1",
-                "strip-ansi": "^3.0.1",
-                "wide-align": "^1.1.0"
-              }
-            },
-            "is-fullwidth-code-point": {
-              "version": "1.0.0",
-              "bundled": true,
-              "dev": true,
-              "requires": {
-                "number-is-nan": "^1.0.0"
-              }
-            },
-            "npmlog": {
-              "version": "4.1.2",
-              "bundled": true,
-              "dev": true,
-              "requires": {
-                "are-we-there-yet": "~1.1.2",
-                "console-control-strings": "~1.1.0",
-                "gauge": "~2.7.3",
-                "set-blocking": "~2.0.0"
-              }
-            },
-            "string-width": {
-              "version": "1.0.2",
-              "bundled": true,
-              "dev": true,
-              "requires": {
-                "code-point-at": "^1.0.0",
-                "is-fullwidth-code-point": "^1.0.0",
-                "strip-ansi": "^3.0.0"
-              }
-            }
           }
         },
         "nopt": {
@@ -6976,18 +6796,18 @@
           }
         },
         "normalize-package-data": {
-          "version": "3.0.3",
+          "version": "4.0.0",
           "bundled": true,
           "dev": true,
           "requires": {
-            "hosted-git-info": "^4.0.1",
-            "is-core-module": "^2.5.0",
-            "semver": "^7.3.4",
-            "validate-npm-package-license": "^3.0.1"
+            "hosted-git-info": "^5.0.0",
+            "is-core-module": "^2.8.1",
+            "semver": "^7.3.5",
+            "validate-npm-package-license": "^3.0.4"
           }
         },
         "npm-audit-report": {
-          "version": "2.1.5",
+          "version": "3.0.0",
           "bundled": true,
           "dev": true,
           "requires": {
@@ -7003,7 +6823,7 @@
           }
         },
         "npm-install-checks": {
-          "version": "4.0.0",
+          "version": "5.0.0",
           "bundled": true,
           "dev": true,
           "requires": {
@@ -7016,56 +6836,58 @@
           "dev": true
         },
         "npm-package-arg": {
-          "version": "8.1.5",
+          "version": "9.0.2",
           "bundled": true,
           "dev": true,
           "requires": {
-            "hosted-git-info": "^4.0.1",
-            "semver": "^7.3.4",
-            "validate-npm-package-name": "^3.0.0"
+            "hosted-git-info": "^5.0.0",
+            "semver": "^7.3.5",
+            "validate-npm-package-name": "^4.0.0"
           }
         },
         "npm-packlist": {
-          "version": "2.2.2",
+          "version": "5.0.0",
           "bundled": true,
           "dev": true,
           "requires": {
-            "glob": "^7.1.6",
-            "ignore-walk": "^3.0.3",
-            "npm-bundled": "^1.1.1",
+            "glob": "^7.2.0",
+            "ignore-walk": "^5.0.1",
+            "npm-bundled": "^1.1.2",
             "npm-normalize-package-bin": "^1.0.1"
           }
         },
         "npm-pick-manifest": {
-          "version": "6.1.1",
+          "version": "7.0.1",
           "bundled": true,
           "dev": true,
           "requires": {
-            "npm-install-checks": "^4.0.0",
+            "npm-install-checks": "^5.0.0",
             "npm-normalize-package-bin": "^1.0.1",
-            "npm-package-arg": "^8.1.2",
-            "semver": "^7.3.4"
+            "npm-package-arg": "^9.0.0",
+            "semver": "^7.3.5"
           }
         },
         "npm-profile": {
-          "version": "5.0.4",
+          "version": "6.0.2",
           "bundled": true,
           "dev": true,
           "requires": {
-            "npm-registry-fetch": "^11.0.0"
+            "npm-registry-fetch": "^13.0.0",
+            "proc-log": "^2.0.0"
           }
         },
         "npm-registry-fetch": {
-          "version": "11.0.0",
+          "version": "13.1.0",
           "bundled": true,
           "dev": true,
           "requires": {
-            "make-fetch-happen": "^9.0.1",
-            "minipass": "^3.1.3",
-            "minipass-fetch": "^1.3.0",
+            "make-fetch-happen": "^10.0.6",
+            "minipass": "^3.1.6",
+            "minipass-fetch": "^2.0.3",
             "minipass-json-stream": "^1.0.1",
-            "minizlib": "^2.0.0",
-            "npm-package-arg": "^8.0.0"
+            "minizlib": "^2.1.2",
+            "npm-package-arg": "^9.0.1",
+            "proc-log": "^2.0.0"
           }
         },
         "npm-user-validate": {
@@ -7074,41 +6896,15 @@
           "dev": true
         },
         "npmlog": {
-          "version": "5.0.1",
+          "version": "6.0.1",
           "bundled": true,
           "dev": true,
           "requires": {
-            "are-we-there-yet": "^2.0.0",
+            "are-we-there-yet": "^3.0.0",
             "console-control-strings": "^1.1.0",
-            "gauge": "^3.0.0",
+            "gauge": "^4.0.0",
             "set-blocking": "^2.0.0"
-          },
-          "dependencies": {
-            "are-we-there-yet": {
-              "version": "2.0.0",
-              "bundled": true,
-              "dev": true,
-              "requires": {
-                "delegates": "^1.0.0",
-                "readable-stream": "^3.6.0"
-              }
-            }
           }
-        },
-        "number-is-nan": {
-          "version": "1.0.1",
-          "bundled": true,
-          "dev": true
-        },
-        "oauth-sign": {
-          "version": "0.9.0",
-          "bundled": true,
-          "dev": true
-        },
-        "object-assign": {
-          "version": "4.1.1",
-          "bundled": true,
-          "dev": true
         },
         "once": {
           "version": "1.4.0",
@@ -7132,39 +6928,41 @@
           }
         },
         "pacote": {
-          "version": "11.3.5",
+          "version": "13.1.1",
           "bundled": true,
           "dev": true,
           "requires": {
-            "@npmcli/git": "^2.1.0",
-            "@npmcli/installed-package-contents": "^1.0.6",
-            "@npmcli/promise-spawn": "^1.2.0",
-            "@npmcli/run-script": "^1.8.2",
-            "cacache": "^15.0.5",
+            "@npmcli/git": "^3.0.0",
+            "@npmcli/installed-package-contents": "^1.0.7",
+            "@npmcli/promise-spawn": "^3.0.0",
+            "@npmcli/run-script": "^3.0.1",
+            "cacache": "^16.0.0",
             "chownr": "^2.0.0",
             "fs-minipass": "^2.1.0",
             "infer-owner": "^1.0.4",
-            "minipass": "^3.1.3",
-            "mkdirp": "^1.0.3",
-            "npm-package-arg": "^8.0.1",
-            "npm-packlist": "^2.1.4",
-            "npm-pick-manifest": "^6.0.0",
-            "npm-registry-fetch": "^11.0.0",
+            "minipass": "^3.1.6",
+            "mkdirp": "^1.0.4",
+            "npm-package-arg": "^9.0.0",
+            "npm-packlist": "^5.0.0",
+            "npm-pick-manifest": "^7.0.0",
+            "npm-registry-fetch": "^13.0.1",
+            "proc-log": "^2.0.0",
             "promise-retry": "^2.0.1",
-            "read-package-json-fast": "^2.0.1",
+            "read-package-json": "^5.0.0",
+            "read-package-json-fast": "^2.0.3",
             "rimraf": "^3.0.2",
-            "ssri": "^8.0.1",
-            "tar": "^6.1.0"
+            "ssri": "^9.0.0",
+            "tar": "^6.1.11"
           }
         },
         "parse-conflict-json": {
-          "version": "1.1.1",
+          "version": "2.0.2",
           "bundled": true,
           "dev": true,
           "requires": {
-            "json-parse-even-better-errors": "^2.3.0",
-            "just-diff": "^3.0.1",
-            "just-diff-apply": "^3.0.0"
+            "json-parse-even-better-errors": "^2.3.1",
+            "just-diff": "^5.0.1",
+            "just-diff-apply": "^5.2.0"
           }
         },
         "path-is-absolute": {
@@ -7172,13 +6970,8 @@
           "bundled": true,
           "dev": true
         },
-        "performance-now": {
-          "version": "2.1.0",
-          "bundled": true,
-          "dev": true
-        },
         "proc-log": {
-          "version": "1.0.0",
+          "version": "2.0.1",
           "bundled": true,
           "dev": true
         },
@@ -7214,23 +7007,8 @@
             "read": "1"
           }
         },
-        "psl": {
-          "version": "1.8.0",
-          "bundled": true,
-          "dev": true
-        },
-        "punycode": {
-          "version": "2.1.1",
-          "bundled": true,
-          "dev": true
-        },
         "qrcode-terminal": {
           "version": "0.12.0",
-          "bundled": true,
-          "dev": true
-        },
-        "qs": {
-          "version": "6.5.2",
           "bundled": true,
           "dev": true
         },
@@ -7243,19 +7021,19 @@
           }
         },
         "read-cmd-shim": {
-          "version": "2.0.0",
+          "version": "3.0.0",
           "bundled": true,
           "dev": true
         },
         "read-package-json": {
-          "version": "4.1.1",
+          "version": "5.0.0",
           "bundled": true,
           "dev": true,
           "requires": {
-            "glob": "^7.1.1",
-            "json-parse-even-better-errors": "^2.3.0",
-            "normalize-package-data": "^3.0.0",
-            "npm-normalize-package-bin": "^1.0.0"
+            "glob": "^7.2.0",
+            "json-parse-even-better-errors": "^2.3.1",
+            "normalize-package-data": "^4.0.0",
+            "npm-normalize-package-bin": "^1.0.1"
           }
         },
         "read-package-json-fast": {
@@ -7288,54 +7066,6 @@
             "once": "^1.3.0"
           }
         },
-        "request": {
-          "version": "2.88.2",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "aws-sign2": "~0.7.0",
-            "aws4": "^1.8.0",
-            "caseless": "~0.12.0",
-            "combined-stream": "~1.0.6",
-            "extend": "~3.0.2",
-            "forever-agent": "~0.6.1",
-            "form-data": "~2.3.2",
-            "har-validator": "~5.1.3",
-            "http-signature": "~1.2.0",
-            "is-typedarray": "~1.0.0",
-            "isstream": "~0.1.2",
-            "json-stringify-safe": "~5.0.1",
-            "mime-types": "~2.1.19",
-            "oauth-sign": "~0.9.0",
-            "performance-now": "^2.1.0",
-            "qs": "~6.5.2",
-            "safe-buffer": "^5.1.2",
-            "tough-cookie": "~2.5.0",
-            "tunnel-agent": "^0.6.0",
-            "uuid": "^3.3.2"
-          },
-          "dependencies": {
-            "form-data": {
-              "version": "2.3.3",
-              "bundled": true,
-              "dev": true,
-              "requires": {
-                "asynckit": "^0.4.0",
-                "combined-stream": "^1.0.6",
-                "mime-types": "^2.1.12"
-              }
-            },
-            "tough-cookie": {
-              "version": "2.5.0",
-              "bundled": true,
-              "dev": true,
-              "requires": {
-                "psl": "^1.1.28",
-                "punycode": "^2.1.1"
-              }
-            }
-          }
-        },
         "retry": {
           "version": "0.12.0",
           "bundled": true,
@@ -7357,14 +7087,15 @@
         "safer-buffer": {
           "version": "2.1.2",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "semver": {
-          "version": "7.3.5",
+          "version": "7.3.6",
           "bundled": true,
           "dev": true,
           "requires": {
-            "lru-cache": "^6.0.0"
+            "lru-cache": "^7.4.0"
           }
         },
         "set-blocking": {
@@ -7373,7 +7104,7 @@
           "dev": true
         },
         "signal-exit": {
-          "version": "3.0.3",
+          "version": "3.0.7",
           "bundled": true,
           "dev": true
         },
@@ -7383,16 +7114,16 @@
           "dev": true
         },
         "socks": {
-          "version": "2.6.1",
+          "version": "2.6.2",
           "bundled": true,
           "dev": true,
           "requires": {
             "ip": "^1.1.5",
-            "smart-buffer": "^4.1.0"
+            "smart-buffer": "^4.2.0"
           }
         },
         "socks-proxy-agent": {
-          "version": "6.1.0",
+          "version": "6.1.1",
           "bundled": true,
           "dev": true,
           "requires": {
@@ -7425,28 +7156,12 @@
           }
         },
         "spdx-license-ids": {
-          "version": "3.0.10",
+          "version": "3.0.11",
           "bundled": true,
           "dev": true
         },
-        "sshpk": {
-          "version": "1.16.1",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "asn1": "~0.2.3",
-            "assert-plus": "^1.0.0",
-            "bcrypt-pbkdf": "^1.0.0",
-            "dashdash": "^1.12.0",
-            "ecc-jsbn": "~0.1.1",
-            "getpass": "^0.1.1",
-            "jsbn": "~0.1.0",
-            "safer-buffer": "^2.0.2",
-            "tweetnacl": "~0.14.0"
-          }
-        },
         "ssri": {
-          "version": "8.0.1",
+          "version": "9.0.0",
           "bundled": true,
           "dev": true,
           "requires": {
@@ -7454,27 +7169,13 @@
           }
         },
         "string-width": {
-          "version": "2.1.1",
+          "version": "4.2.3",
           "bundled": true,
           "dev": true,
           "requires": {
-            "is-fullwidth-code-point": "^2.0.0",
-            "strip-ansi": "^4.0.0"
-          },
-          "dependencies": {
-            "ansi-regex": {
-              "version": "3.0.0",
-              "bundled": true,
-              "dev": true
-            },
-            "strip-ansi": {
-              "version": "4.0.0",
-              "bundled": true,
-              "dev": true,
-              "requires": {
-                "ansi-regex": "^3.0.0"
-              }
-            }
+            "emoji-regex": "^8.0.0",
+            "is-fullwidth-code-point": "^3.0.0",
+            "strip-ansi": "^6.0.1"
           }
         },
         "string_decoder": {
@@ -7485,17 +7186,12 @@
             "safe-buffer": "~5.2.0"
           }
         },
-        "stringify-package": {
-          "version": "1.0.1",
-          "bundled": true,
-          "dev": true
-        },
         "strip-ansi": {
-          "version": "3.0.1",
+          "version": "6.0.1",
           "bundled": true,
           "dev": true,
           "requires": {
-            "ansi-regex": "^2.0.0"
+            "ansi-regex": "^5.0.1"
           }
         },
         "supports-color": {
@@ -7530,30 +7226,9 @@
           "dev": true
         },
         "treeverse": {
-          "version": "1.0.4",
+          "version": "2.0.0",
           "bundled": true,
           "dev": true
-        },
-        "tunnel-agent": {
-          "version": "0.6.0",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "safe-buffer": "^5.0.1"
-          }
-        },
-        "tweetnacl": {
-          "version": "0.14.5",
-          "bundled": true,
-          "dev": true
-        },
-        "typedarray-to-buffer": {
-          "version": "3.1.5",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "is-typedarray": "^1.0.0"
-          }
         },
         "unique-filename": {
           "version": "1.1.1",
@@ -7571,21 +7246,8 @@
             "imurmurhash": "^0.1.4"
           }
         },
-        "uri-js": {
-          "version": "4.4.1",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "punycode": "^2.1.0"
-          }
-        },
         "util-deprecate": {
           "version": "1.0.2",
-          "bundled": true,
-          "dev": true
-        },
-        "uuid": {
-          "version": "3.4.0",
           "bundled": true,
           "dev": true
         },
@@ -7599,21 +7261,11 @@
           }
         },
         "validate-npm-package-name": {
-          "version": "3.0.0",
+          "version": "4.0.0",
           "bundled": true,
           "dev": true,
           "requires": {
-            "builtins": "^1.0.3"
-          }
-        },
-        "verror": {
-          "version": "1.10.0",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "assert-plus": "^1.0.0",
-            "core-util-is": "1.0.2",
-            "extsprintf": "^1.2.0"
+            "builtins": "^5.0.0"
           }
         },
         "walk-up-path": {
@@ -7638,11 +7290,11 @@
           }
         },
         "wide-align": {
-          "version": "1.1.3",
+          "version": "1.1.5",
           "bundled": true,
           "dev": true,
           "requires": {
-            "string-width": "^1.0.2 || 2"
+            "string-width": "^1.0.2 || 2 || 3 || 4"
           }
         },
         "wrappy": {
@@ -7651,14 +7303,12 @@
           "dev": true
         },
         "write-file-atomic": {
-          "version": "3.0.3",
+          "version": "4.0.1",
           "bundled": true,
           "dev": true,
           "requires": {
             "imurmurhash": "^0.1.4",
-            "is-typedarray": "^1.0.0",
-            "signal-exit": "^3.0.2",
-            "typedarray-to-buffer": "^3.1.5"
+            "signal-exit": "^3.0.7"
           }
         },
         "yallist": {
@@ -8773,16 +8423,16 @@
       }
     },
     "semantic-release": {
-      "version": "17.4.7",
-      "resolved": "https://registry.npmjs.org/semantic-release/-/semantic-release-17.4.7.tgz",
-      "integrity": "sha512-3Ghu8mKCJgCG3QzE5xphkYWM19lGE3XjFdOXQIKBM2PBpBvgFQ/lXv31oX0+fuN/UjNFO/dqhNs8ATLBhg6zBg==",
+      "version": "19.0.2",
+      "resolved": "https://registry.npmjs.org/semantic-release/-/semantic-release-19.0.2.tgz",
+      "integrity": "sha512-7tPonjZxukKECmClhsfyMKDt0GR38feIC2HxgyYaBi+9tDySBLjK/zYDLhh+m6yjnHIJa9eBTKYE7k63ZQcYbw==",
       "dev": true,
       "requires": {
-        "@semantic-release/commit-analyzer": "^8.0.0",
-        "@semantic-release/error": "^2.2.0",
-        "@semantic-release/github": "^7.0.0",
-        "@semantic-release/npm": "^7.0.0",
-        "@semantic-release/release-notes-generator": "^9.0.0",
+        "@semantic-release/commit-analyzer": "^9.0.2",
+        "@semantic-release/error": "^3.0.0",
+        "@semantic-release/github": "^8.0.0",
+        "@semantic-release/npm": "^9.0.0",
+        "@semantic-release/release-notes-generator": "^10.0.0",
         "aggregate-error": "^3.0.0",
         "cosmiconfig": "^7.0.0",
         "debug": "^4.0.0",
@@ -8795,8 +8445,8 @@
         "hook-std": "^2.0.0",
         "hosted-git-info": "^4.0.0",
         "lodash": "^4.17.21",
-        "marked": "^2.0.0",
-        "marked-terminal": "^4.1.1",
+        "marked": "^4.0.10",
+        "marked-terminal": "^5.0.0",
         "micromatch": "^4.0.2",
         "p-each-series": "^2.1.0",
         "p-reduce": "^2.0.0",
@@ -8808,6 +8458,12 @@
         "yargs": "^16.2.0"
       },
       "dependencies": {
+        "@semantic-release/error": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/@semantic-release/error/-/error-3.0.0.tgz",
+          "integrity": "sha512-5hiM4Un+tpl4cKw3lV4UgzJj+SmfNIDCLLw0TepzQxz9ZGV5ixnqkzIVF+3tp0ZHgcMKE+VNGHJjEeyFG2dcSw==",
+          "dev": true
+        },
         "cliui": {
           "version": "7.0.4",
           "resolved": "https://registry.npmjs.org/cliui/-/cliui-7.0.4.tgz",

--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
     "husky": "4.3.8",
     "jest": "26.6.3",
     "prettier": "2.2.1",
-    "semantic-release": "17.4.7",
+    "semantic-release": "19.0.2",
     "ts-jest": "26.5.0",
     "ts-node": "9.1.1",
     "typescript": "4.1.3"


### PR DESCRIPTION
Addresses CVE-2022-21681, CVE-2022-21680